### PR TITLE
Fix inline pre parsing

### DIFF
--- a/src/util/__fixtures__/sample-blocks.ts
+++ b/src/util/__fixtures__/sample-blocks.ts
@@ -36,10 +36,14 @@ export const old_style_gist_block_content =
   '</div>' +
   'Text after gist';
 
-// Taken from 2017-12-05-android-architecture-components
-export const sample_inline_pre = `
+/*
+    Taken from 2017-12-05-android-architecture-components
+    Any pre with a lang should result in a fenced code block,
+    or at minimum, because this pre is on it's on line,
+    it should end up on it's own line (with surrounding empty lines) in the MD
+    NOTE: This example also has ” added to the lang
+ */
+export const sample_single_line_pre = `
 To get started with adding ViewModel, you must first add:
-<pre lang="”java”">implementation "android.arch.lifecycle:extensions:1.0.0"
-
-</pre>
+<pre lang="”java”">implementation "android.arch.lifecycle:extensions:1.0.0"</pre>
 to your application build.gradle file.`;

--- a/src/util/__fixtures__/sample-blocks.ts
+++ b/src/util/__fixtures__/sample-blocks.ts
@@ -35,3 +35,11 @@ export const old_style_gist_block_content =
   ' </div>' +
   '</div>' +
   'Text after gist';
+
+// Taken from 2017-12-05-android-architecture-components
+export const sample_inline_pre = `
+To get started with adding ViewModel, you must first add:
+<pre lang="”java”">implementation "android.arch.lifecycle:extensions:1.0.0"
+
+</pre>
+to your application build.gradle file.`;

--- a/src/util/__tests__/__snapshots__/to-markdown.ts.snap
+++ b/src/util/__tests__/__snapshots__/to-markdown.ts.snap
@@ -12,13 +12,11 @@ angular.module(‘example’)
 "
 `;
 
-exports[`pre translation to code fence it translates addjs links 1`] = `
-"Angular 1.x: \\\\\`\`\`
-    angular.module(‘example’)
-	.controller(‘ExampleCtrl’, function() {
-});
-  \`\`\` Angular 2.0: \\\\\`\`\`
-    import {Component, View} from 'angular2/angular2';
+exports[`pre translation to code fence addjs2 1`] = `
+"
+
+\`\`\`ts
+import {Component, View} from 'angular2/angular2';
 
 @Component({
   selector: 'example'
@@ -29,7 +27,36 @@ exports[`pre translation to code fence it translates addjs links 1`] = `
 })
 
 export class Example {}
-  \`\`\`"
+\`\`\`
+
+"
+`;
+
+exports[`pre translation to code fence it translates addjs links 1`] = `
+"Angular 1.x: 
+
+\`\`\`js
+angular.module(‘example’)
+	.controller(‘ExampleCtrl’, function() {
+});
+\`\`\`
+
+ Angular 2.0: 
+
+\`\`\`ts
+import {Component, View} from 'angular2/angular2';
+
+@Component({
+  selector: 'example'
+})
+
+@View({
+  templateUrl: './components/example/example.html'
+})
+
+export class Example {}
+\`\`\`
+"
 `;
 
 exports[`pre translation to code fence it translates pre block with language 1`] = `

--- a/src/util/__tests__/__snapshots__/to-markdown.ts.snap
+++ b/src/util/__tests__/__snapshots__/to-markdown.ts.snap
@@ -34,9 +34,8 @@ export class Example {}
 
 exports[`pre translation to code fence it translates pre block with language 1`] = `
 "\`\`\`groovy
-import groovy.xml.MarkupBuilder  
-  
-def xml = new MarkupBuilder()
+import groovy_xml_MarkupBuilder
+def xml = new MarkupBuilder
 \`\`\`
 "
 `;

--- a/src/util/__tests__/__snapshots__/to-markdown.ts.snap
+++ b/src/util/__tests__/__snapshots__/to-markdown.ts.snap
@@ -1,11 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`pre translation to code fence addjs 1`] = `
-"\`\`\`
-    angular.module(‘example’)
+"
+
+\`\`\`js
+angular.module(‘example’)
 	.controller(‘ExampleCtrl’, function() {
 });
-  \`\`\`"
+\`\`\`
+
+"
 `;
 
 exports[`pre translation to code fence it translates addjs links 1`] = `
@@ -26,4 +30,13 @@ exports[`pre translation to code fence it translates addjs links 1`] = `
 
 export class Example {}
   \`\`\`"
+`;
+
+exports[`pre translation to code fence it translates pre block with language 1`] = `
+"\`\`\`groovy
+import groovy.xml.MarkupBuilder  
+  
+def xml = new MarkupBuilder()
+\`\`\`
+"
 `;

--- a/src/util/__tests__/to-markdown.ts
+++ b/src/util/__tests__/to-markdown.ts
@@ -1,5 +1,15 @@
 import { isMarkdown, toMarkdown, addjsToCodeFence } from '../to-markdown';
-import { old_style_gist_block_content } from '../__fixtures__/sample-blocks';
+import {
+  old_style_gist_block_content,
+  sample_inline_pre,
+} from '../__fixtures__/sample-blocks';
+
+const turnDownBr = '\n  '; // https://github.com/domchristie/turndown/issues/160#issuecomment-238814993
+
+const extractMarkdown = ({ markdown }) => {
+  console.log(markdown);
+  return markdown;
+};
 
 test('it detects markdown', () => {
   [
@@ -78,43 +88,38 @@ test('double br breaks turns into spacing paragraphs in md', async () => {
 
 describe('pre translation to code fence', () => {
   test('it translates simple pre block', async () => {
-    expect(
-      await toMarkdown(`
+    const content = `
 <pre>
 alert('hello world');
 
 alert('hi');
 </pre>
-    `).then(result => result.markdown)
-    ).toBe(
+`;
+    expect(await toMarkdown(content).then(extractMarkdown)).toBe(
       `
+<!-- TODO: Add language to code block -->
 \`\`\`
 alert('hello world');
 
 alert('hi');
 \`\`\`
-    `.trim()
+
+`.trim()
     );
   });
 
   test('it translates pre block with language', async () => {
-    expect(
-      await toMarkdown(`
+    const content = `
 <pre lang="groovy">
 import groovy.xml.MarkupBuilder
 
 def xml = new MarkupBuilder()
 </pre>
-    `).then(result => result.markdown)
-    ).toBe(
-      `
-\`\`\`groovy
-import groovy.xml.MarkupBuilder
+`;
 
-def xml = new MarkupBuilder()
-\`\`\`
-    `.trim()
-    );
+    expect(
+      await toMarkdown(content).then(result => result.markdown)
+    ).toMatchSnapshot();
   });
 
   test('it does _not_ apply code fence to a block without a new line', async () => {
@@ -127,6 +132,14 @@ var a = 'b';
     ).toBe("`var a = 'b';`\n");
   });
 
+  test('it ensures a new line both before and after code fence', async () => {
+    expect(await toMarkdown(sample_inline_pre).then(extractMarkdown)).toBe(
+      'To get started with adding ViewModel, you must first add:' +
+        '\n\n`implementation "android.arch.lifecycle:extensions:1.0.0"`\n\n' +
+        'to your application build.gradle file.\n'
+    );
+  });
+
   test('addjs', async () => {
     const result = await addjsToCodeFence(
       '[addjs src="https://gist.github.com/JakePartusch/50737c37e988759e66b6.js?file=angular-controller.js"\\]'
@@ -135,11 +148,10 @@ var a = 'b';
   });
 
   test('it translates addjs links', async () => {
-    expect(
-      await toMarkdown(`
+    const content = `
     Angular 1.x: \[addjs src="https://gist.github.com/JakePartusch/50737c37e988759e66b6.js?file=angular-controller.js"\] Angular 2.0: \[addjs src="https://gist.github.com/JakePartusch/d5863172113a92fc493d.js?file=angular2-component.ts"\]
-    `).then(result => result.markdown)
-    ).toMatchSnapshot();
+    `;
+    expect(await toMarkdown(content).then(extractMarkdown)).toMatchSnapshot();
   });
 
   test('it translates old style gist blocks', async () => {

--- a/src/util/__tests__/to-markdown.ts
+++ b/src/util/__tests__/to-markdown.ts
@@ -1,13 +1,11 @@
 import { isMarkdown, toMarkdown, addjsToCodeFence } from '../to-markdown';
 import {
   old_style_gist_block_content,
-  sample_inline_pre,
+  sample_single_line_pre,
 } from '../__fixtures__/sample-blocks';
 
-const turnDownBr = '\n  '; // https://github.com/domchristie/turndown/issues/160#issuecomment-238814993
-
 const extractMarkdown = ({ markdown }) => {
-  console.log(markdown);
+  //console.log(markdown);
   return markdown;
 };
 
@@ -123,20 +121,22 @@ alert('hi');
     expect(markdown).toMatchSnapshot();
   });
 
-  test('it does _not_ apply code fence to a block without a new line', async () => {
+  test('it does _not_ apply code fence to a block without a new line (if there is no lang)', async () => {
     expect(
       await toMarkdown(`
-<pre lang="js">
+<pre>
 var a = 'b';
 </pre>
     `).then(result => result.markdown)
     ).toBe("`var a = 'b';`\n");
   });
 
-  test('it ensures a new line both before and after code fence', async () => {
-    expect(await toMarkdown(sample_inline_pre).then(extractMarkdown)).toBe(
+  test('it ensures single line pre elements with a lang are code fenced', async () => {
+    expect(await toMarkdown(sample_single_line_pre).then(extractMarkdown)).toBe(
       'To get started with adding ViewModel, you must first add:' +
-        '\n\n`implementation "android.arch.lifecycle:extensions:1.0.0"`\n\n' +
+        '\n\n```java\n' +
+        'implementation "android.arch.lifecycle:extensions:1.0.0"\n' +
+        '```\n\n' +
         'to your application build.gradle file.\n'
     );
   });
@@ -145,6 +145,14 @@ var a = 'b';
     const result = await addjsToCodeFence(
       '[addjs src="https://gist.github.com/JakePartusch/50737c37e988759e66b6.js?file=angular-controller.js"\\]'
     );
+    expect(result).toMatchSnapshot();
+  });
+
+  test('addjs2', async () => {
+    const content = `
+    Angular 1.x: \[addjs src="https://gist.github.com/JakePartusch/50737c37e988759e66b6.js?file=angular-controller.js"\] Angular 2.0: \[addjs src="https://gist.github.com/JakePartusch/d5863172113a92fc493d.js?file=angular2-component.ts"\]
+    `;
+    const result = await addjsToCodeFence(content);
     expect(result).toMatchSnapshot();
   });
 

--- a/src/util/__tests__/to-markdown.ts
+++ b/src/util/__tests__/to-markdown.ts
@@ -87,7 +87,7 @@ test('double br breaks turns into spacing paragraphs in md', async () => {
 });
 
 describe('pre translation to code fence', () => {
-  test('it translates simple pre block', async () => {
+  test('it translates simple pre block WITHOUT a language', async () => {
     const content = `
 <pre>
 alert('hello world');
@@ -95,31 +95,32 @@ alert('hello world');
 alert('hi');
 </pre>
 `;
+    /*
+        remark stringify treats ``` w/o a lang differently, strips the ``` replaces with indents
+       */
     expect(await toMarkdown(content).then(extractMarkdown)).toBe(
-      `
-<!-- TODO: Add language to code block -->
-\`\`\`
-alert('hello world');
+      `<!-- TODO: Add language to code block -->
 
-alert('hi');
-\`\`\`
-
-`.trim()
+    alert('hello world');  
+      
+    alert('hi');
+`
     );
   });
 
   test('it translates pre block with language', async () => {
-    const content = `
-<pre lang="groovy">
-import groovy.xml.MarkupBuilder
+    const content =
+      '<pre lang="groovy">\n' +
+      'import groovy_xml_MarkupBuilder\n' +
+      'def xml = new MarkupBuilder' +
+      '</pre>';
+    const markdown = await toMarkdown(content).then(extractMarkdown);
+    // basic check to make sure the lang as added after the ```
+    expect(markdown).toMatch(
+      /```groovy\nimport groovy.xml.MarkupBuilder\s*?\ndef xml = new MarkupBuilder\s*?\n```/
+    );
 
-def xml = new MarkupBuilder()
-</pre>
-`;
-
-    expect(
-      await toMarkdown(content).then(result => result.markdown)
-    ).toMatchSnapshot();
+    expect(markdown).toMatchSnapshot();
   });
 
   test('it does _not_ apply code fence to a block without a new line', async () => {

--- a/src/util/to-markdown.ts
+++ b/src/util/to-markdown.ts
@@ -29,8 +29,9 @@ export function isMarkdown(html: string): boolean {
 }
 
 export async function toMarkdown(html: string): Promise<MarkdownResult> {
-  let content = html.replace(/\n\s*?\n/gi, '<br/><br/>');
+  let content = html.replace(/[\s\t]*?\n[\s\t]*?\n/gi, '<br/><br/>');
   let markdown = escape(turndown.turndown(content.trim()).trim());
+
   let addjsReplacements = 0;
   if (hasAddjsLink(markdown)) {
     markdown = markdown.replace('addjs="', 'addjs src="'); //Replace the one occurrence of missing ` src`
@@ -77,6 +78,7 @@ export async function toMarkdown(html: string): Promise<MarkdownResult> {
   const frames = $('iframe, object').map(function(i, el) {
     return $(this).attr('src');
   });
+
   const ast = map(remark.parse(markdown), node => {
     if (node.type === 'image' && node.url.indexOf(WORDPRESS_UPLOAD_PATH) > -1) {
       const imagePath = node.url.split(WORDPRESS_UPLOAD_PATH).pop();

--- a/src/util/turndown.ts
+++ b/src/util/turndown.ts
@@ -31,22 +31,17 @@ service.addRule('old-gh-gist', {
 service.addRule('code-fencing', {
   filter: ['pre'],
   replacement(content, node) {
-    const contentBeforeEscape = content;
-    console.log('Content before escape');
-    console.log(contentBeforeEscape);
+    const lang = node.getAttribute('lang');
     const trimmed = escape(content ? content.trim() : '');
-    console.log('Content after escape (and trim)');
-    console.log(trimmed);
     let result;
-    // Surround with single or triple ticks based on if it has a new line in the content
-    if (trimmed.match('\n')) {
-      console.log('Matched new line');
-      const lang = node.getAttribute('lang');
+
+    // Surround with single or triple ticks based on if it has a new line in the content or lang attrib
+    if (trimmed.match('\n') || lang) {
       result = [
         '',
         '',
         lang === null ? '<!-- TODO: Add language to code block -->' : '',
-        '```' + (lang === null ? '' : lang),
+        '```' + (lang === null ? '' : lang.replace(/”/g, '')),
         trimmed,
         '```',
         '',
@@ -55,9 +50,6 @@ service.addRule('code-fencing', {
     } else {
       result = ['`', trimmed, '`'].join('');
     }
-
-    console.log('Final PRE code-fencing result');
-    console.log(result);
 
     return result;
   },

--- a/src/util/turndown.ts
+++ b/src/util/turndown.ts
@@ -31,19 +31,35 @@ service.addRule('old-gh-gist', {
 service.addRule('code-fencing', {
   filter: ['pre'],
   replacement(content, node) {
+    const contentBeforeEscape = content;
+    console.log('Content before escape');
+    console.log(contentBeforeEscape);
     const trimmed = escape(content ? content.trim() : '');
+    console.log('Content after escape (and trim)');
+    console.log(trimmed);
+    let result;
+    // Surround with single or triple ticks based on if it has a new line in the content
     if (trimmed.match('\n')) {
+      console.log('Matched new line');
       const lang = node.getAttribute('lang');
-      return [
+      result = [
+        '',
         '',
         lang === null ? '<!-- TODO: Add language to code block -->' : '',
         '```' + (lang === null ? '' : lang),
         trimmed,
         '```',
         '',
+        '',
       ].join('\n');
+    } else {
+      result = ['`', trimmed, '`'].join('');
     }
-    return ['`', trimmed, '`'].join('');
+
+    console.log('Final PRE code-fencing result');
+    console.log(result);
+
+    return result;
   },
 });
 


### PR DESCRIPTION
feat(pre): fix pre tags w/ lang attribs not being code fenced
    
    This was originally meant to handle
    2017/12/21/use-a-terraform-wrapper-script-to-easily-manage-terraform-installations
    but while working to get all tests passing, I found the issue was
    really more around handling <pre> elements with vs without
    lang attributes.  Looking at what we had in our export file, everything
